### PR TITLE
Lowercase addresses when finding index

### DIFF
--- a/apps/frontend/contexts/MerkleContext.tsx
+++ b/apps/frontend/contexts/MerkleContext.tsx
@@ -36,7 +36,9 @@ export const MerkleProvider = ({ children }) => {
     if (!address) {
       return;
     }
-    const index = addresses["addresses"].findIndex((addr) => addr === address);
+    const index = addresses["addresses"].findIndex(
+      (addr) => addr.toLowerCase() === address.toLowerCase()
+    );
     try {
       const proof = tree.getProof(index, address);
       setNode({


### PR DESCRIPTION
- Some addresses in the addresses are lowercased which breaks an assumption when we search for the NFT index.